### PR TITLE
ransackの検索機能の名前の欄を部分一致に変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,6 @@ class User < ApplicationRecord
   attr_accessor :search_name, :search_age
 
   def search
-    User.ransack(name_eq: @search_name, age_eq: @search_age).result
+    User.ransack(name_cont: @search_name, age_eq: @search_age).result
   end
 end


### PR DESCRIPTION
名前を検索する際に、「藤」や「田」を含むという部分一致で検索できるように変更しました。